### PR TITLE
Addedd -z option to specify "size" parameter in the template in case you are passing filepaths with -d

### DIFF
--- a/tools/genfio
+++ b/tools/genfio
@@ -54,6 +54,8 @@ show_help() {
 					Default is $IODEPTH
 -d disk1[,disk2,disk3,..]	: Run the tests on the selected disks
 					Separated each disk with a comma
+-z filesize                     : Specify the working file size, if you are passing filepaths to -d
+                                        Disabled by default
 -r seconds			: Time in seconds per benchmark
 					0 means till the end of the device
 					Default is $RUNTIME seconds
@@ -203,7 +205,7 @@ esac
 }
 
 parse_cmdline() {
-while getopts "hacpsd:b:r:m:x:D:A:B:" opt; do
+while getopts "hacpsd:b:r:m:x:z:D:A:B:" opt; do
   case $opt in
     h)
 	show_help
@@ -259,6 +261,10 @@ while getopts "hacpsd:b:r:m:x:D:A:B:" opt; do
       ;;
     A)
 	echo "exec_postrun=$OPTARG" >> $TEMPLATE
+      ;;
+    z)
+	FSIZE=$OPTARG
+	echo "size=$FSIZE" >> $TEMPLATE
       ;;
     \?)
       echo "Invalid option: -$OPTARG" >&2


### PR DESCRIPTION
If you are using regular files instead of devices to perform fio tests, it is necessary to specify the size of the file to be created. This small patch implements the -z option.
